### PR TITLE
Allow non-normalized dates in temperature data loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 Information about version updates and instructions for upgrading where
 needed.
 
+## Development
+
+* Allow using non-normalized dates, (i.e., dates with non-zero minutes or
+  seconds that do not fall exactly on an hour or a day boundary) to access
+  `station.load_isd_hourly_temp_data`, `station.load_isd_daily_temp_data`,
+  and `station.load_gsod_daily_temp_data`.
+
 ## 0.3.6
 
 * Bug fix in ISDStation initialization with handling of null fields.

--- a/eeweather/ranking.py
+++ b/eeweather/ranking.py
@@ -331,7 +331,8 @@ def select_station(
         else:
             start_date, end_date = coverage_range
             try:
-                tempC = eeweather.mockable.load_isd_hourly_temp_data(station, start_date, end_date)
+                tempC = eeweather.mockable.load_isd_hourly_temp_data(
+                    station, start_date, end_date)
             except ISDDataNotAvailableError:
                 return False  # reject
 

--- a/eeweather/stations.py
+++ b/eeweather/stations.py
@@ -776,15 +776,26 @@ def load_isd_hourly_temp_data(usaf_id, start, end, read_from_cache=True, write_t
         for year in range(start.year, end.year + 1)
     ]
 
-    # get raw data
+    # get raw data from loaded years into hourly form
     ts = pd.concat(data).resample('H').mean()
 
-    # whittle down
+    # whittle down to desired range
     ts = ts[start:end]
 
-    # fill in gaps
-    ts = ts.reindex(pd.date_range(start, end, freq='H'))
+    if len(ts) > 0:
+        # because start and end dates need.to fall exactly on hours
+        ts_start = datetime(
+            start.year, start.month, start.day, start.hour, tzinfo=pytz.UTC)
+        # add an hour if not already exactly on an hour, which guarantees
+        # that ts_start is greater than or equal to start.
+        if ts_start < start:
+            ts_start += timedelta(seconds=3600)
+        ts_end = datetime(
+            end.year, end.month, end.day, end.hour, tzinfo=pytz.UTC)
+        # fill in gaps
+        ts = ts.reindex(pd.date_range(ts_start, ts_end, freq='H', tz=pytz.UTC))
     return ts
+
 
 
 def load_isd_daily_temp_data(usaf_id, start, end, read_from_cache=True, write_to_cache=True):
@@ -808,8 +819,17 @@ def load_isd_daily_temp_data(usaf_id, start, end, read_from_cache=True, write_to
     # whittle down
     ts = ts[start:end]
 
-    # fill in gaps
-    ts = ts.reindex(pd.date_range(start, end, freq='D', tz=pytz.UTC))
+    if len(ts) > 0:
+        # because start and end dates need.to fall exactly on days
+        ts_start = datetime(
+            start.year, start.month, start.day, tzinfo=pytz.UTC)
+        # add a day if not already exactly on a day, which guarantees
+        # that ts_start is greater than or equal to start.
+        if ts_start < start:
+            ts_start += timedelta(days=1)
+        ts_end = datetime(end.year, end.month, end.day, tzinfo=pytz.UTC)
+        # fill in gaps
+        ts = ts.reindex(pd.date_range(ts_start, ts_end, freq='D', tz=pytz.UTC))
     return ts
 
 
@@ -833,8 +853,17 @@ def load_gsod_daily_temp_data(usaf_id, start, end, read_from_cache=True, write_t
     # whittle down
     ts = ts[start:end]
 
-    # fill in gaps
-    ts = ts.reindex(pd.date_range(start, end, freq='D', tz=pytz.UTC))
+    if len(ts) > 0:
+        # because start and end dates need.to fall exactly on days
+        ts_start = datetime(
+            start.year, start.month, start.day, tzinfo=pytz.UTC)
+        # add a day if not already exactly on a day, which guarantees
+        # that ts_start is greater than or equal to start.
+        if ts_start < start:
+            ts_start += timedelta(days=1)
+        ts_end = datetime(end.year, end.month, end.day, tzinfo=pytz.UTC)
+        # fill in gaps
+        ts = ts.reindex(pd.date_range(ts_start, ts_end, freq='D', tz=pytz.UTC))
     return ts
 
 

--- a/tests/test_stations.py
+++ b/tests/test_stations.py
@@ -1291,6 +1291,18 @@ def test_load_isd_hourly_temp_data(
     assert pd.notnull(ts[-1])
 
 
+def test_load_isd_hourly_temp_data_non_normalized_dates(
+        monkeypatch_noaa_ftp, monkeypatch_key_value_store):
+
+    start = datetime(2006, 1, 3, 11, 12, 13, tzinfo=pytz.UTC)
+    end = datetime(2007, 4, 3, 12, 13, 14, tzinfo=pytz.UTC)
+    ts = load_isd_hourly_temp_data('722874', start, end)
+    assert ts.index[0] == datetime(2006, 1, 3, 12, tzinfo=pytz.UTC)
+    assert pd.isnull(ts[0])
+    assert ts.index[-1] == datetime(2007, 4, 3, 12, tzinfo=pytz.UTC)
+    assert pd.notnull(ts[-1])
+
+
 def test_load_isd_daily_temp_data(
         monkeypatch_noaa_ftp, monkeypatch_key_value_store):
 
@@ -1303,6 +1315,18 @@ def test_load_isd_daily_temp_data(
     assert pd.notnull(ts[-1])
 
 
+def test_load_isd_daily_temp_data_non_normalized_dates(
+        monkeypatch_noaa_ftp, monkeypatch_key_value_store):
+
+    start = datetime(2006, 1, 3, 11, 12, 13, tzinfo=pytz.UTC)
+    end = datetime(2007, 4, 3, 12, 13, 14, tzinfo=pytz.UTC)
+    ts = load_isd_daily_temp_data('722874', start, end)
+    assert ts.index[0] == datetime(2006, 1, 4, tzinfo=pytz.UTC)
+    assert pd.isnull(ts[0])
+    assert ts.index[-1] == datetime(2007, 4, 3, tzinfo=pytz.UTC)
+    assert pd.notnull(ts[-1])
+
+
 def test_load_gsod_daily_temp_data(
         monkeypatch_noaa_ftp, monkeypatch_key_value_store):
 
@@ -1312,6 +1336,18 @@ def test_load_gsod_daily_temp_data(
     assert ts.index[0] == start
     assert pd.isnull(ts[0])
     assert ts.index[-1] == end
+    assert pd.notnull(ts[-1])
+
+
+def test_load_gsod_daily_temp_data_non_normalized_dates(
+        monkeypatch_noaa_ftp, monkeypatch_key_value_store):
+
+    start = datetime(2006, 1, 3, 11, 12, 13, tzinfo=pytz.UTC)
+    end = datetime(2007, 4, 3, 12, 13, 14, tzinfo=pytz.UTC)
+    ts = load_gsod_daily_temp_data('722874', start, end)
+    assert ts.index[0] == datetime(2006, 1, 4, tzinfo=pytz.UTC)
+    assert pd.isnull(ts[0])
+    assert ts.index[-1] == datetime(2007, 4, 3, tzinfo=pytz.UTC)
     assert pd.notnull(ts[-1])
 
 


### PR DESCRIPTION
Fixes an annoyance that previously disallowed using non-normalized dates, (i.e., dates with non-zero minutes or seconds that do not fall exactly on an hour or a day boundary) to be used to access `station.load_isd_hourly_temp_data`, `station.load_isd_daily_temp_data`, and `station.load_gsod_daily_temp_data`. This is now possible.