### PR TITLE
added parameter to either null or error on missing years

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ Changelog
 Development
 -----------
 
-* [placeholder]
+* Add `error_on_missing_years` parameter to `load_isd_hourly_temp_data`,
+  if True, an ISDDataAvailableError exception is raised if there are years,
+  within the requested dates that are unavailable. If False, the values in
+  the missing years are set to nan.
 
 0.3.8
 -----

--- a/eeweather/stations.py
+++ b/eeweather/stations.py
@@ -783,8 +783,12 @@ def load_cz2010_hourly_temp_data_cached_proxy(
 
 
 def load_isd_hourly_temp_data(
-    usaf_id, start, end, read_from_cache=True, write_to_cache=True,
-    error_on_missing_years=True
+    usaf_id,
+    start,
+    end,
+    read_from_cache=True,
+    write_to_cache=True,
+    error_on_missing_years=True,
 ):
 
     # CalTRACK 2.3.3

--- a/eeweather/stations.py
+++ b/eeweather/stations.py
@@ -783,7 +783,8 @@ def load_cz2010_hourly_temp_data_cached_proxy(
 
 
 def load_isd_hourly_temp_data(
-    usaf_id, start, end, read_from_cache=True, write_to_cache=True
+    usaf_id, start, end, read_from_cache=True, write_to_cache=True,
+    error_on_missing_years=True
 ):
 
     # CalTRACK 2.3.3
@@ -791,15 +792,30 @@ def load_isd_hourly_temp_data(
         raise NonUTCTimezoneInfoError(start)
     if end.tzinfo != pytz.UTC:
         raise NonUTCTimezoneInfoError(start)
-    data = [
-        load_isd_hourly_temp_data_cached_proxy(
-            usaf_id,
-            year,
-            read_from_cache=read_from_cache,
-            write_to_cache=write_to_cache,
-        )
-        for year in range(start.year, end.year + 1)
-    ]
+    if not error_on_missing_years:
+        data = []
+        for year in range(start.year, end.year + 1):
+            try:
+                data.append(
+                    load_isd_hourly_temp_data_cached_proxy(
+                        usaf_id,
+                        year,
+                        read_from_cache=read_from_cache,
+                        write_to_cache=write_to_cache,
+                    )
+                )
+            except ISDDataNotAvailableError:
+                pass
+    else:
+        data = [
+            load_isd_hourly_temp_data_cached_proxy(
+                usaf_id,
+                year,
+                read_from_cache=read_from_cache,
+                write_to_cache=write_to_cache,
+            )
+            for year in range(start.year, end.year + 1)
+        ]
 
     # get raw data from loaded years into hourly form
     ts = pd.concat(data).resample("H").mean()

--- a/tests/test_stations.py
+++ b/tests/test_stations.py
@@ -1820,8 +1820,7 @@ def test_isd_station_metadata_null_elevation():
 
 
 def test_load_isd_hourly_temp_data_missing_years(
-    monkeypatch_noaa_ftp,
-    monkeypatch_key_value_store
+    monkeypatch_noaa_ftp, monkeypatch_key_value_store
 ):
     start = datetime(2005, 1, 1, tzinfo=pytz.UTC)
     end = datetime(2007, 12, 31, tzinfo=pytz.UTC)

--- a/tests/test_stations.py
+++ b/tests/test_stations.py
@@ -1817,3 +1817,18 @@ def test_isd_station_metadata_null_elevation():
     assert metadata["elevation"] is None
     isd_station = ISDStation(usaf_id)
     assert isd_station.elevation is None
+
+
+def test_load_isd_hourly_temp_data_missing_years(
+    monkeypatch_noaa_ftp,
+    monkeypatch_key_value_store
+):
+    start = datetime(2005, 1, 1, tzinfo=pytz.UTC)
+    end = datetime(2007, 12, 31, tzinfo=pytz.UTC)
+    with pytest.raises(ISDDataNotAvailableError):
+        ts = load_isd_hourly_temp_data("722874", start, end)
+    ts = load_isd_hourly_temp_data("722874", start, end, error_on_missing_years=False)
+    assert ts.index[0] == start
+    assert pd.isnull(ts[0])
+    assert ts.index[-1] == end
+    assert pd.notnull(ts[-1])


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure tests pass and coverage has not fallen `docker-compose run --rm test`.
- [x] Update the [CHANGELOG.md](../CHANGELOG.md) to describe your changes in a bulleted list under the "Development" section at the top of the changelog. If this section does not exist, create it.
- [x] Make sure code style follows PEP 008 using `docker-compose run --rm blacken`.

### Description

Allows a parameter to be used that determines whether weather data with missing years of data returns an exception or NaNs.
