### PR TITLE
Be more direct about cache insert / update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 Development
 -----------
 
-* Placeholder
+* Make cache insert / update more explicit. Prevents potential race condition in multi-threaded environment.
 
 0.3.19
 ------


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure tests pass and coverage has not fallen `docker-compose run --rm test`.
- [x] Update the [CHANGELOG.md](../CHANGELOG.md) to describe your changes in a bulleted list under the "Development" section at the top of the changelog. If this section does not exist, create it.
- [x] Make sure code style follows PEP 008 using `docker-compose run --rm blacken`.

### Description

This resolves an issue in multi-process environments where multiple workers can retrieve a record and then try to insert them at the same time. This tries an insert first and then updates the record if the insertion fails. The difference between this and existing code is it doesn't poll for the key first (which might have changed in the interim).