### PR TITLE
Allow newer versions of pyproj

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ from shutil import rmtree
 from setuptools import find_packages, setup, Command
 
 NAME = "eeweather"
-REQUIRED = ["click", "pandas", "pyproj==1.9.6", "requests", "shapely"]
+REQUIRED = ["click", "pandas", "pyproj>=1.9.6", "requests", "shapely"]
 
 here = os.path.abspath(os.path.dirname(__file__))
 


### PR DESCRIPTION
Looks like an earlier commit* was merely overspecific. pyproj is up to 2.6.0** now, and geopandas requires at least 2.2.0***. Tests pass with 2.6.0:

> 240 passed in 63.00 seconds

*= https://github.com/openeemeter/eeweather/commit/39415113f4bc8d3bea5445f4b27d561a3a2a1622
**= https://pypi.org/project/pyproj
***= https://github.com/geopandas/geopandas/commit/1d212b2a0c2a993f7d3b9a505f314be37b99a7d7