### PR TITLE
Check for UTC timezone without using pytz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Development
 -----------
 
 * Placeholder
+* Check for UTC tzinfo datetimes in station functions without explicitly using pytz
 
 0.3.25
 ------

--- a/eeweather/stations.py
+++ b/eeweather/stations.py
@@ -17,7 +17,7 @@
    limitations under the License.
 
 """
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import gzip
 import json
 import pkg_resources
@@ -109,6 +109,15 @@ __all__ = (
     "load_cached_tmy3_hourly_temp_data",
     "load_cached_cz2010_hourly_temp_data",
 )
+
+
+def _datetime_is_utc(dt):
+    orig_tzinfo = dt.tzinfo
+    return (
+        False
+        if orig_tzinfo is None
+        else dt.utcoffset().seconds == 0
+    )
 
 
 def get_isd_filenames(usaf_id, target_year=None, filename_format=None, with_host=False):
@@ -811,9 +820,9 @@ def load_isd_hourly_temp_data(
 ):
     warnings = []
     # CalTRACK 2.3.3
-    if start.tzinfo != pytz.UTC:
+    if not _datetime_is_utc(start):
         raise NonUTCTimezoneInfoError(start)
-    if end.tzinfo != pytz.UTC:
+    if not _datetime_is_utc(end):
         raise NonUTCTimezoneInfoError(end)
     if not error_on_missing_years:
         data = []
@@ -949,9 +958,9 @@ def load_tmy3_hourly_temp_data(
     usaf_id, start, end, read_from_cache=True, write_to_cache=True, fetch_from_web=True
 ):
     # CalTRACK 2.3.3
-    if start.tzinfo != pytz.UTC:
+    if not _datetime_is_utc(start):
         raise NonUTCTimezoneInfoError(start)
-    if end.tzinfo != pytz.UTC:
+    if not _datetime_is_utc(end):
         raise NonUTCTimezoneInfoError(end)
     single_year_data = load_tmy3_hourly_temp_data_cached_proxy(
         usaf_id,
@@ -982,9 +991,9 @@ def load_cz2010_hourly_temp_data(
     usaf_id, start, end, read_from_cache=True, write_to_cache=True, fetch_from_web=True
 ):
     # CalTRACK 2.3.3
-    if start.tzinfo != pytz.UTC:
+    if not _datetime_is_utc(start):
         raise NonUTCTimezoneInfoError(start)
-    if end.tzinfo != pytz.UTC:
+    if not _datetime_is_utc(end):
         raise NonUTCTimezoneInfoError(end)
     single_year_data = load_cz2010_hourly_temp_data_cached_proxy(
         usaf_id,


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure tests pass and coverage has not fallen `docker-compose run --rm test`.
- [x] Update the [CHANGELOG.md](../CHANGELOG.md) to describe your changes in a bulleted list under the "Development" section at the top of the changelog. If this section does not exist, create it.
- [x] Make sure code style follows PEP 008 using `docker-compose run --rm blacken`.
- [x] Make sure that new functions and classes have inline docstrings and are
  included in [docs/api.rst](../docs/api.rst) for the sphinx build. Please use [numpy-style docstrings](https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html#google-vs-numpy).
  Sphinx docs can be built with the following command: `docker-compose run --rm --entrypoint="make -C docs html" shell`. Please note and fix any warnings.
- [x] Make sure that all git commits are have the "Signed-off-by" message for
  the Developer Certificate of Origin. When you're making a commit, just add
  the `-s/--signoff` flag (e.g., `git commit -s`).

### Description

Since there are multiple valid ways of declaring a `datetime` instance to be in the UTC timezone, this PR represents a library-agnostic approach that does not explicitly check for `tzinfo==pytz.UTC` but achieves the same end.

See `dateutil` and `datetime.timezone` for 2 examples of alternatives to pytz.