### PR TITLE
Copy shared station metadata dataframe when ranking for thread-safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 Development
 -----------
 
-* Placeholder
+* Copy shared station metadata dataframe when ranking for thread-safety
 
 0.3.27
 -------

--- a/eeweather/ranking.py
+++ b/eeweather/ranking.py
@@ -200,7 +200,7 @@ def rank_stations(
           available.
 
     """
-    candidates = cached_data.all_station_metadata
+    candidates = cached_data.all_station_metadata.copy()
 
     # compute distances
     candidates_defined_lat_long = candidates[


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure tests pass and coverage has not fallen `docker-compose run --rm test`.
- [x] Update the [CHANGELOG.md](../CHANGELOG.md) to describe your changes in a bulleted list under the "Development" section at the top of the changelog. If this section does not exist, create it.
- [x] Make sure code style follows PEP 008 using `docker-compose run --rm blacken`.
- [x] Make sure that new functions and classes have inline docstrings and are
  included in [docs/api.rst](../docs/api.rst) for the sphinx build. Please use [numpy-style docstrings](https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html#google-vs-numpy).
  Sphinx docs can be built with the following command: `docker-compose run --rm --entrypoint="make -C docs html" shell`. Please note and fix any warnings.
- [x] Make sure that all git commits are have the "Signed-off-by" message for
  the Developer Certificate of Origin. When you're making a commit, just add
  the `-s/--signoff` flag (e.g., `git commit -s`).

### Description

We ran into transient issues when calling rank_stations() in a multithreaded process--the cached attribute `all_station_metadata` was previously being directly modified and could result in mismatched station distance calculations.